### PR TITLE
Fix ATH scroll-into-view with nested page scrollers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,6 @@ axes.values().combinations {
               '-Penable-jacoco',
               '--update-snapshots',
               "-Dmaven.repo.local=$m2repo",
-              '-Dtest=ManagementLinkTest#links',
               '-Dmaven.test.failure.ignore',
               '-DforkCount=2',
               '-Dspotbugs.failOnError=false',

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2415,14 +2415,26 @@ public class Functions {
     }
 
     /**
-     * Returns whether sticky positioning of UI elements should be disabled via the
-     * {@code disableStickyPositioning} cookie (primarily for UI acceptance tests).
-     * Sticky elements can otherwise float over the element under test and intercept clicks.
+     * Returns whether sticky positioning / nested page scrollers should be disabled for UI
+     * acceptance tests.
+     *
+     * <p>Enabled when either:
+     * <ul>
+     *   <li>the {@code hudson.Functions.disableStickyPositioning} system property is {@code true}
+     *       (preferred — set by ATH on the Jenkins-under-test JVM), or</li>
+     *   <li>the {@code disableStickyPositioning} cookie is {@code true}</li>
+     * </ul>
+     *
+     * <p>Sticky elements and nested {@code overflow-y: auto} panes otherwise prevent Selenium from
+     * scrolling targets into view / intercept clicks.
      */
     @Restricted(NoExternalUse.class)
     public static boolean isStickyPositioningDisabled() {
+        if (SystemProperties.getBoolean(Functions.class.getName() + ".disableStickyPositioning")) {
+            return true;
+        }
         String cookieValue = Functions.getCookie(Stapler.getCurrentRequest2(), "disableStickyPositioning", null);
-        return Boolean.valueOf(cookieValue);
+        return Boolean.parseBoolean(cookieValue);
     }
 
     @Deprecated

--- a/src/main/scss/base/_sticky.scss
+++ b/src/main/scss/base/_sticky.scss
@@ -1,16 +1,27 @@
-// When sticky positioning is disabled (hudson.Functions.disableStickyPositioning, used by
-// acceptance tests), neutralise every sticky element so it cannot float over and intercept
-// clicks.
-// Keep this list in sync with the `position: sticky` rules across the SCSS sources.
+// When sticky positioning is disabled (hudson.Functions.disableStickyPositioning system
+// property or disableStickyPositioning cookie, used by acceptance tests), neutralise every
+// sticky element and flatten nested scroll containers so Selenium can scroll targets into view.
+// Keep this list in sync with the `position: sticky` / overflow rules across the SCSS sources.
 :root[data-disable-sticky="true"] {
+  // Nested overflow panes break Firefox/Selenium scrollIntoView; force document scrolling.
+  overscroll-behavior: auto !important;
+
+  body {
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
   .app-page-body {
     height: auto !important;
+    max-height: none !important;
     overflow: visible !important;
   }
 
   .app-page-body > .app-page-body__sidebar,
   .app-page-body > .app-page-body__contents {
-    overflow-y: visible !important;
+    overflow: visible !important;
+    max-height: none !important;
   }
 
   .jenkins-app-bar--sticky,


### PR DESCRIPTION
## Summary
- Honor `hudson.Functions.disableStickyPositioning` as a **system property** (in addition to the cookie) so ATH does not depend on fragile remote-WebDriver cookie injection
- Strengthen `:root[data-disable-sticky="true"]` CSS to fully flatten nested `.app-page-body` scrollers back to document scrolling
- Restore the full unit test suite in `Jenkinsfile` (it was narrowed to `ManagementLinkTest#links`, which is why CI looked green)

## Why
Selenium/Firefox cannot reliably `scrollIntoView` / click elements inside nested `overflow-y: auto` panes. The cookie + flatten CSS was the right idea, but:
1. Cookie injection can fail silently in CI (`catch` + continue)
2. Cookie is applied without a reload, so the first render still has scrollers
3. A JVM system property is set once at launch and applies to every page

## Test plan
- [ ] Merge into `individual-scrollers`, wait for incremental
- [ ] Point [ATH PR 2750](https://github.com/jenkinsci/acceptance-test-harness/pull/2750) at the new incremental **and** include the companion ATH change that sets `-Dhudson.Functions.disableStickyPositioning=true`
- [ ] Confirm previously failing splits pass (elements scroll into view)

Companion ATH PR: will link after creation.